### PR TITLE
Add Support for SPM and CocoaPods, Bump Version to 2.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ fastlane/test_output
 ## Playgrounds
 timeline.xctimeline
 playground.xcworkspace
+.swiftpm
+TradeDoublerDemo/.DS_Store
+.DS_Store

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:5.1
+import PackageDescription
+
+let package = Package(
+    name: "tradedoubler-ios-sdk",
+    platforms: [.iOS(.v13), .macOS(.v10_15)],
+    products: [
+        .library(name: "tradedoubler-ios-sdk", targets: ["TradeDoublerSDK"])
+    ],
+    targets: [
+        .target(
+            name: "TradeDoublerSDK",
+            path: "TradeDoublerDemo/TradeDoublerSDK"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ Then run the following command in your terminal:
 pod install
 ```
 
+While integrating the library using CocoaPods, you may encounter the following error:
+```
+Sandbox: rsync.samba(13105) deny(1) file-write-create
+```
+
+This error usually occurs if your project uses default build settings. To resolve this issue, you can try the setting the `ENABLE_USER_SCRIPT_SANDBOXING` to 'No'. 
+
+For more details check [StackOverflow discussion](https://stackoverflow.com/questions/76590131/error-while-build-ios-app-in-xcode-sandbox-rsync-samba-13105-deny1-file-w/76626156#76626156).
+
 #### Carthage
 
 If you prefer to use Carthage, follow the instructions below.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Especially, if you are working on Xcode 13.0 or newer, you should carefully read
 If Carthage is already installed, add the framework to your project by including this line in your Cartfile:
 
 ```
-github "https://github.com/tradedoubler/tradedoubler-ios-sdk.git" ~> 2.1.0
+github "https://github.com/tradedoubler/tradedoubler-ios-sdk.git" ~> 2.2.0
 ```
 After downloading the repository with Carthage, you'll need to configure the dependencies manually in the build phases of your project.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 ### Installation
 
-Framework installation is possible using either Carthage or Swift Package Manager (SPM) dependency managers.
+Framework installation is possible using Swift Package Manager (SPM), CocoaPods or Carthage dependency managers.
+
 
 #### Swift Package Manager (SPM)
 
@@ -19,6 +20,19 @@ https://github.com/tradedoubler/tradedoubler-ios-sdk.git
 3. Choose version 2.2.0 or newer and add the package to your project.
 
 SPM will automatically handle the downloading and integration of the library into your project.
+
+#### CocoaPods
+
+To integrate the library using CocoaPods, add the following line to your `Podfile`:
+
+```ruby
+pod 'TradeDoublerSDK', '~> 2.2.0'
+```
+Then run the following command in your terminal:
+
+```bash
+pod install
+```
 
 #### Carthage
 

--- a/README.md
+++ b/README.md
@@ -4,21 +4,40 @@
 
 ### Installation
 
-Framework installation is possible using Carthage dependency manager. If you've never done that before please use Carthage official documentation, it's really helpful:
+Framework installation is possible using either Carthage or Swift Package Manager (SPM) dependency managers.
+
+#### Swift Package Manager (SPM)
+
+Starting from version **2.2.0**, the library can be integrated using Swift Package Manager. 
+To integrate the library using SPM, follow these steps:
+
+1. In Xcode, go to `File` > `Add Package Dependencies...`
+2. Enter the URL of the repository in the search field:
+```
+https://github.com/tradedoubler/tradedoubler-ios-sdk.git
+```
+3. Choose version 2.2.0 or newer and add the package to your project.
+
+SPM will automatically handle the downloading and integration of the library into your project.
+
+#### Carthage
+
+If you prefer to use Carthage, follow the instructions below.
+
+If you've never used Carthage before, please refer to the official Carthage documentation for guidance:
 
 [https://github.com/Carthage/Carthage](https://github.com/Carthage/Carthage)
 
-Especially, if you are working on Xcode 13.0 or newer, you should carefully read informations about necessary workaround:
+Especially, if you are working on Xcode 13.0 or newer, you should carefully read the information about the necessary workaround:
 
 [https://github.com/Carthage/Carthage/blob/master/Documentation/Xcode12Workaround.md](https://github.com/Carthage/Carthage/blob/master/Documentation/Xcode12Workaround.md)
 
-If carthage is already installed then to add framework to your project please add this line in your Cartfile:
+If Carthage is already installed, add the framework to your project by including this line in your Cartfile:
 
 ```
 github "https://github.com/tradedoubler/tradedoubler-ios-sdk.git" ~> 2.1.0
 ```
-
-After downloading the repository from Carthage you need to configure dependencies manually in build phases of your project. 
+After downloading the repository with Carthage, you'll need to configure the dependencies manually in the build phases of your project.
 
 **Min SDK Version**
 

--- a/TradeDoublerSDK.podspec
+++ b/TradeDoublerSDK.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "13.0"
     s.osx.deployment_target = "10.15"
   
-    s.source        = { :git => "https://github.com/onevcat/TradeDoublerSDK.git", :tag => s.version }
+    s.source        = { :git => "https://github.com/tradedoubler/tradedoubler-ios-sdk.git", :tag => s.version }
     s.source_files  = ["TradeDoublerDemo/TradeDoublerSDK/*.swift"]
   
     s.requires_arc = true

--- a/TradeDoublerSDK.podspec
+++ b/TradeDoublerSDK.podspec
@@ -1,0 +1,26 @@
+Pod::Spec.new do |s|
+
+    s.name         = "TradeDoublerSDK"
+    s.version      = "2.2.0"
+    s.summary      = "TradeDoubler SDK for iOS."
+  
+    s.description  = <<-DESC
+                     TradeDoubler SDK for iOS. 
+                     DESC
+  
+    s.homepage     = "https://github.com/tradedoubler/tradedoubler-ios-sdk"
+  
+    # s.license      = { :type => "MIT", :file => "LICENSE" }
+  
+    s.authors      = { "TradeDoubler" => "marketing@tradedoubler.com" }
+  
+    s.swift_versions = ['5.0']
+  
+    s.ios.deployment_target = "13.0"
+    s.osx.deployment_target = "10.15"
+  
+    s.source        = { :git => "https://github.com/onevcat/TradeDoublerSDK.git", :tag => s.version }
+    s.source_files  = ["TradeDoublerDemo/TradeDoublerSDK/*.swift"]
+  
+    s.requires_arc = true
+  end


### PR DESCRIPTION
This pull request introduces support for Swift Package Manager (SPM) and CocoaPods to our iOS library, enabling easier integration and management of the library in various projects.
Additionally, the library version has been bumped to 2.2.0 to reflect these significant updates.

## Key Changes:

* **Swift Package Manager (SPM) Support:** Added the necessary configuration to support SPM
* **CocoaPods Support:** Updated the project to include a Podspec file
* **Version Bump:** Updated the library version from 2.1.0 to 2.2.0

## Additional Details:

* Updated the README to include instructions for integrating the library using SPM and CocoaPods.
* Ensured backward compatibility with existing Carthage users.

## Testing:

* Verified successful integration via SPM and CocoaPods in sample projects.
* Conducted regression testing to ensure no existing functionality was impacted by these changes.
* Additional integration tests will be performed once we create 2.2.0 tag.

## Next Steps:

* Merge this PR to the development branch.
* Merge development to the main branch.
* Final tests when tag 2.2.0 is live.
